### PR TITLE
Added Circular Queue to ToFu Data Structure Collection

### DIFF
--- a/code/logic/cqueue.c
+++ b/code/logic/cqueue.c
@@ -1,0 +1,182 @@
+/*
+ * -----------------------------------------------------------------------------
+ * Project: Fossil Logic
+ *
+ * This file is part of the Fossil Logic project, which aims to develop high-
+ * performance, cross-platform applications and libraries. The code contained
+ * herein is subject to the terms and conditions defined in the project license.
+ *
+ * Author: Michael Gene Brockus (Dreamer)
+ *
+ * Copyright (C) 2024 Fossil Logic. All rights reserved.
+ * -----------------------------------------------------------------------------
+ */
+#include "fossil/tofu/cqueue.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// *****************************************************************************
+// Function prototypes
+// *****************************************************************************
+
+fossil_cqueue_t* fossil_cqueue_create_container(char* type, size_t capacity) {
+    fossil_cqueue_t* queue = (fossil_cqueue_t*)malloc(sizeof(fossil_cqueue_t));
+    if (queue == NULL) {
+        return NULL;
+    }
+    queue->front = NULL;
+    queue->rear = NULL;
+    queue->type = fossil_tofu_strdup(type);
+    queue->capacity = capacity;
+    queue->size = 0;
+    return queue;
+}
+
+fossil_cqueue_t* fossil_cqueue_create_default(void) {
+    return fossil_cqueue_create_container("any", 0);
+}
+
+fossil_cqueue_t* fossil_cqueue_create_copy(const fossil_cqueue_t* other) {
+    fossil_cqueue_t* queue = (fossil_cqueue_t*)malloc(sizeof(fossil_cqueue_t));
+    if (queue == NULL) {
+        return NULL;
+    }
+    queue->type = fossil_tofu_strdup(other->type);
+    queue->capacity = other->capacity;
+    queue->size = other->size;
+    queue->front = NULL;
+    queue->rear = NULL;
+
+    fossil_cqueue_node_t* current = other->front;
+    if (current != NULL) {
+        do {
+            fossil_cqueue_insert(queue, current->data.value.data);
+            current = current->next;
+        } while (current != other->front);  // Continue until we reach the head node again
+    }
+    return queue;
+}
+
+fossil_cqueue_t* fossil_cqueue_create_move(fossil_cqueue_t* other) {
+    fossil_cqueue_t* queue = (fossil_cqueue_t*)malloc(sizeof(fossil_cqueue_t));
+    if (queue == NULL) {
+        return NULL;
+    }
+    queue->type = other->type;
+    queue->capacity = other->capacity;
+    queue->size = other->size;
+    queue->front = other->front;
+    queue->rear = other->rear;
+    other->front = NULL;
+    other->rear = NULL;
+    return queue;
+}
+
+void fossil_cqueue_destroy(fossil_cqueue_t* queue) {
+    if (queue == NULL) {
+        return;
+    }
+    fossil_cqueue_node_t* current = queue->front;
+    while (current != NULL) {
+        fossil_cqueue_node_t* next = current->next;
+        fossil_tofu_destroy(&current->data);
+        free(current);
+        current = next;
+    }
+    free(queue->type);
+    free(queue);
+}
+
+// *****************************************************************************
+// Utility functions
+// *****************************************************************************
+
+int32_t fossil_cqueue_insert(fossil_cqueue_t* queue, char *data) {
+    if (queue->size >= queue->capacity) {
+        return FOSSIL_TOFU_FAILURE;  // Queue is full
+    }
+    fossil_cqueue_node_t* node = (fossil_cqueue_node_t*)malloc(sizeof(fossil_cqueue_node_t));
+    if (node == NULL) {
+        return FOSSIL_TOFU_FAILURE;  // Memory allocation failed
+    }
+    node->data = fossil_tofu_create(queue->type, data);
+    node->next = NULL;
+    if (queue->front == NULL) {
+        queue->front = node;
+        queue->rear = node;
+        node->next = node;  // Circular link
+    } else {
+        queue->rear->next = node;
+        queue->rear = node;
+        node->next = queue->front;  // Circular link
+    }
+    queue->size++;
+    return FOSSIL_TOFU_SUCCESS;
+}
+
+int32_t fossil_cqueue_remove(fossil_cqueue_t* queue) {
+    if (queue->front == NULL) {
+        return FOSSIL_TOFU_FAILURE;  // Queue is empty
+    }
+    fossil_cqueue_node_t* node = queue->front;
+    if (queue->front == queue->rear) {  // Only one node in the queue
+        queue->front = NULL;
+        queue->rear = NULL;
+    } else {
+        queue->front = queue->front->next;
+        queue->rear->next = queue->front;  // Maintain circular link
+    }
+    fossil_tofu_destroy(&node->data);
+    free(node);
+    queue->size--;
+    return FOSSIL_TOFU_SUCCESS;
+}
+
+size_t fossil_cqueue_size(const fossil_cqueue_t* queue) {
+    return queue->size;
+}
+
+bool fossil_cqueue_not_empty(const fossil_cqueue_t* queue) {
+    return queue->size > 0;
+}
+
+bool fossil_cqueue_not_cnullptr(const fossil_cqueue_t* queue) {
+    return queue != NULL;
+}
+
+bool fossil_cqueue_is_empty(const fossil_cqueue_t* queue) {
+    return queue->size == 0;
+}
+
+bool fossil_cqueue_is_cnullptr(const fossil_cqueue_t* queue) {
+    return queue == NULL;
+}
+
+char *fossil_cqueue_get_front(const fossil_cqueue_t* queue) {
+    if (queue->front == NULL) {
+        return NULL;  // Queue is empty
+    }
+    return fossil_tofu_get_value(&queue->front->data);
+}
+
+char *fossil_cqueue_get_rear(const fossil_cqueue_t* queue) {
+    if (queue->rear == NULL) {
+        return NULL;  // Queue is empty
+    }
+    return fossil_tofu_get_value(&queue->rear->data);
+}
+
+void fossil_cqueue_set_front(fossil_cqueue_t* queue, char *element) {
+    if (queue->front == NULL) {
+        return;  // Queue is empty
+    }
+    fossil_tofu_set_value(&queue->front->data, element);
+}
+
+void fossil_cqueue_set_rear(fossil_cqueue_t* queue, char *element) {
+    if (queue->rear == NULL) {
+        return;  // Queue is empty
+    }
+    fossil_tofu_set_value(&queue->rear->data, element);
+}

--- a/code/logic/cqueue.c
+++ b/code/logic/cqueue.c
@@ -77,6 +77,9 @@ void fossil_cqueue_destroy(fossil_cqueue_t* queue) {
     if (queue == NULL) {
         return;
     }
+    if (queue->front != NULL) {
+        queue->rear->next = NULL;  // Break the circular link
+    }
     fossil_cqueue_node_t* current = queue->front;
     while (current != NULL) {
         fossil_cqueue_node_t* next = current->next;

--- a/code/logic/fossil/tofu/cqueue.h
+++ b/code/logic/fossil/tofu/cqueue.h
@@ -1,0 +1,377 @@
+/*
+ * -----------------------------------------------------------------------------
+ * Project: Fossil Logic
+ *
+ * This file is part of the Fossil Logic project, which aims to develop high-
+ * performance, cross-platform applications and libraries. The code contained
+ * herein is subject to the terms and conditions defined in the project license.
+ *
+ * Author: Michael Gene Brockus (Dreamer)
+ *
+ * Copyright (C) 2024 Fossil Logic. All rights reserved.
+ * -----------------------------------------------------------------------------
+ */
+#ifndef FOSSIL_TOFU_CQUEUE_H
+#define FOSSIL_TOFU_CQUEUE_H
+
+#include "tofu.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// *****************************************************************************
+// Type definitions
+// *****************************************************************************
+
+// Node structure for the circular queue
+typedef struct fossil_cqueue_node_t {
+    fossil_tofu_t data;
+    struct fossil_cqueue_node_t* next;
+} fossil_cqueue_node_t;
+
+// Circular queue structure
+typedef struct fossil_cqueue_t {
+    fossil_cqueue_node_t* front;
+    fossil_cqueue_node_t* rear;
+    char* type;
+    size_t capacity;
+    size_t size;
+} fossil_cqueue_t;
+
+// *****************************************************************************
+// Function prototypes
+// *****************************************************************************
+
+/**
+ * Create a new circular queue with the specified data type and capacity.
+ *
+ * @param type     The type of data the queue will store.
+ * @param capacity The maximum number of elements the queue can hold.
+ * @return         The created circular queue.
+ * @note           Time complexity: O(1)
+ */
+fossil_cqueue_t* fossil_cqueue_create_container(char* type, size_t capacity);
+
+/**
+ * Create a new circular queue with default values.
+ * 
+ * Time complexity: O(1)
+ *
+ * @return The created circular queue.
+ */
+fossil_cqueue_t* fossil_cqueue_create_default(void);
+
+/**
+ * Create a new circular queue by copying an existing queue.
+ * 
+ * Time complexity: O(n)
+ *
+ * @param other The circular queue to copy.
+ * @return      The created circular queue.
+ */
+fossil_cqueue_t* fossil_cqueue_create_copy(const fossil_cqueue_t* other);
+
+/**
+ * Create a new circular queue by moving an existing queue.
+ * 
+ * Time complexity: O(1)
+ *
+ * @param other The circular queue to move.
+ * @return      The created circular queue.
+ */
+fossil_cqueue_t* fossil_cqueue_create_move(fossil_cqueue_t* other);
+
+/**
+ * Erase the contents of the circular queue and free allocated memory.
+ *
+ * @param queue The circular queue to erase.
+ * @note        Time complexity: O(n)
+ */
+void fossil_cqueue_destroy(fossil_cqueue_t* queue);
+
+// *****************************************************************************
+// Utility functions
+// *****************************************************************************
+
+/**
+ * Insert data into the circular queue.
+ *
+ * @param queue The circular queue to insert data into.
+ * @param data  The data to insert.
+ * @return      The error code indicating the success or failure of the operation.
+ * @note        Time complexity: O(1)
+ */
+int32_t fossil_cqueue_insert(fossil_cqueue_t* queue, char *data);
+
+/**
+ * Remove data from the circular queue.
+ *
+ * @param queue The circular queue to remove data from.
+ * @return      The error code indicating the success or failure of the operation.
+ * @note        Time complexity: O(1)
+ */
+int32_t fossil_cqueue_remove(fossil_cqueue_t* queue);
+
+/**
+ * Get the size of the circular queue.
+ *
+ * @param queue The circular queue for which to get the size.
+ * @return      The size of the circular queue.
+ * @note        Time complexity: O(1)
+ */
+size_t fossil_cqueue_size(const fossil_cqueue_t* queue);
+
+/**
+ * Check if the circular queue is not empty.
+ *
+ * @param queue The circular queue to check.
+ * @return      True if the circular queue is not empty, false otherwise.
+ * @note        Time complexity: O(1)
+ */
+bool fossil_cqueue_not_empty(const fossil_cqueue_t* queue);
+
+/**
+ * Check if the circular queue is not a null pointer.
+ *
+ * @param queue The circular queue to check.
+ * @return      True if the circular queue is not a null pointer, false otherwise.
+ * @note        Time complexity: O(1)
+ */
+bool fossil_cqueue_not_cnullptr(const fossil_cqueue_t* queue);
+
+/**
+ * Check if the circular queue is empty.
+ *
+ * @param queue The circular queue to check.
+ * @return      True if the circular queue is empty, false otherwise.
+ * @note        Time complexity: O(1)
+ */
+bool fossil_cqueue_is_empty(const fossil_cqueue_t* queue);
+
+/**
+ * Check if the circular queue is a null pointer.
+ *
+ * @param queue The circular queue to check.
+ * @return      True if the circular queue is a null pointer, false otherwise.
+ * @note        Time complexity: O(1)
+ */
+bool fossil_cqueue_is_cnullptr(const fossil_cqueue_t* queue);
+
+// *****************************************************************************
+// Getter and setter functions
+// *****************************************************************************
+
+/**
+ * Get the element at the front of the circular queue.
+ * 
+ * Time complexity: O(1)
+ *
+ * @param queue The circular queue from which to get the front element.
+ * @return      The element at the front of the circular queue.
+ */
+char *fossil_cqueue_get_front(const fossil_cqueue_t* queue);
+
+/**
+ * Get the element at the rear of the circular queue.
+ * 
+ * Time complexity: O(1)
+ *
+ * @param queue The circular queue from which to get the rear element.
+ * @return      The element at the rear of the circular queue.
+ */
+char *fossil_cqueue_get_rear(const fossil_cqueue_t* queue);
+
+/**
+ * Set the element at the front of the circular queue.
+ * 
+ * Time complexity: O(1)
+ *
+ * @param queue   The circular queue in which to set the front element.
+ * @param element The element to set at the front.
+ */
+void fossil_cqueue_set_front(fossil_cqueue_t* queue, char *element);
+
+/**
+ * Set the element at the rear of the circular queue.
+ * 
+ * Time complexity: O(1)
+ *
+ * @param queue   The circular queue in which to set the rear element.
+ * @param element The element to set at the rear.
+ */
+void fossil_cqueue_set_rear(fossil_cqueue_t* queue, char *element);
+
+#ifdef __cplusplus
+}
+#include <stdexcept>
+
+namespace fossil {
+
+namespace tofu {
+
+    class CQueue {
+    public:
+        /**
+         * Create a new circular queue with the specified data type.
+         *
+         * @param type The type of data the queue will store.
+         */
+        CQueue(char* type) {
+            queue = fossil_cqueue_create_container(type, 0);
+            if (queue == nullptr) {
+                throw std::runtime_error("Failed to create circular queue.");
+            }
+        }
+
+        /**
+         * Create a new circular queue with default values.
+         */
+        CQueue() {
+            queue = fossil_cqueue_create_default();
+            if (queue == nullptr) {
+                throw std::runtime_error("Failed to create circular queue.");
+            }
+        }
+
+        /**
+         * Create a new circular queue by copying an existing queue.
+         *
+         * @param other The queue to copy.
+         */
+        CQueue(const CQueue& other) {
+            queue = fossil_cqueue_create_copy(other.queue);
+            if (queue == nullptr) {
+                throw std::runtime_error("Failed to create circular queue.");
+            }
+        }
+
+        /**
+         * Create a new circular queue by moving an existing queue.
+         *
+         * @param other The queue to move.
+         */
+        CQueue(CQueue&& other) noexcept {
+            queue = fossil_cqueue_create_move(other.queue);
+            other.queue = nullptr;
+        }
+
+        /**
+         * Destroy the circular queue and free allocated memory.
+         */
+        ~CQueue() {
+            fossil_cqueue_destroy(queue);
+        }
+
+        /**
+         * Insert data into the circular queue.
+         *
+         * @param data The data to insert.
+         * @return     The error code indicating the success or failure of the operation.
+         */
+        int32_t insert(char *data) {
+            return fossil_cqueue_insert(queue, data);
+        }
+
+        /**
+         * Remove data from the circular queue.
+         *
+         * @return The error code indicating the success or failure of the operation.
+         */
+        int32_t remove() {
+            return fossil_cqueue_remove(queue);
+        }
+
+        /**
+         * Get the size of the circular queue.
+         *
+         * @return The size of the circular queue.
+         */
+        size_t size() const {
+            return fossil_cqueue_size(queue);
+        }
+
+        /**
+         * Check if the circular queue is not empty.
+         *
+         * @return True if the circular queue is not empty, false otherwise.
+         */
+        bool not_empty() const {
+            return fossil_cqueue_not_empty(queue);
+        }
+
+        /**
+         * Check if the circular queue is not a null pointer.
+         *
+         * @return True if the circular queue is not a null pointer, false otherwise.
+         */
+        bool not_cnullptr() const {
+            return fossil_cqueue_not_cnullptr(queue);
+        }
+
+        /**
+         * Check if the circular queue is empty.
+         *
+         * @return True if the circular queue is empty, false otherwise.
+         */
+        bool is_empty() const {
+            return fossil_cqueue_is_empty(queue);
+        }
+
+        /**
+         * Check if the circular queue is a null pointer.
+         *
+         * @return True if the circular queue is a null pointer, false otherwise.
+         */
+        bool is_cnullptr() const {
+            return fossil_cqueue_is_cnullptr(queue);
+        }
+
+        /**
+         * Get the element at the front of the circular queue.
+         *
+         * @return The element at the front of the circular queue.
+         */
+        char *get_front() const {
+            return fossil_cqueue_get_front(queue);
+        }
+
+        /**
+         * Get the element at the rear of the circular queue.
+         *
+         * @return The element at the rear of the circular queue.
+         */
+        char *get_rear() const {
+            return fossil_cqueue_get_rear(queue);
+        }
+
+        /**
+         * Set the element at the front of the circular queue.
+         *
+         * @param element The element to set at the front.
+         */
+        void set_front(char *element) {
+            fossil_cqueue_set_front(queue, element);
+        }
+
+        /**
+         * Set the element at the rear of the circular queue.
+         *
+         * @param element The element to set at the rear.
+         */
+        void set_rear(char *element) {
+            fossil_cqueue_set_rear(queue, element);
+        }
+
+    private:
+        fossil_cqueue_t* queue;
+    };
+
+} // namespace tofu
+
+} // namespace fossil
+
+#endif
+
+#endif /* FOSSIL_TOFU_FRAMEWORK_H */

--- a/code/logic/fossil/tofu/cqueue.h
+++ b/code/logic/fossil/tofu/cqueue.h
@@ -218,8 +218,8 @@ namespace tofu {
          *
          * @param type The type of data the queue will store.
          */
-        CQueue(char* type) {
-            queue = fossil_cqueue_create_container(type, 0);
+        CQueue(char* type, size_t capacity) {
+            queue = fossil_cqueue_create_container(type, capacity);
             if (queue == nullptr) {
                 throw std::runtime_error("Failed to create circular queue.");
             }

--- a/code/logic/fossil/tofu/framework.h
+++ b/code/logic/fossil/tofu/framework.h
@@ -21,6 +21,7 @@
 #include "vector.h"
 #include "dqueue.h"
 #include "pqueue.h"
+#include "cqueue.h"
 #include "queue.h"
 #include "stack.h"
 #include "tuple.h"

--- a/code/logic/meson.build
+++ b/code/logic/meson.build
@@ -2,7 +2,7 @@ dir = include_directories('.')
 
 fossil_tofu_lib = library('fossil-tofu',
     files('dlist.c', 'flist.c', 'clist.c',
-          'dqueue.c', 'pqueue.c', 'queue.c',
+          'dqueue.c', 'pqueue.c', 'queue.c', 'cqueue.c',
           'setof.c', 'tuple.c', 'mapof.c',
           'stack.c', 'vector.c', 'tofu.c'),
     install: true,

--- a/code/tests/cases/test_cqueue.c
+++ b/code/tests/cases/test_cqueue.c
@@ -1,0 +1,97 @@
+/*
+ * -----------------------------------------------------------------------------
+ * Project: Fossil Logic
+ *
+ * This file is part of the Fossil Logic project, which aims to develop high-
+ * performance, cross-platform applications and libraries. The code contained
+ * herein is subject to the terms and conditions defined in the project license.
+ *
+ * Author: Michael Gene Brockus (Dreamer)
+ *
+ * Copyright (C) 2024 Fossil Logic. All rights reserved.
+ * -----------------------------------------------------------------------------
+ */
+#include <fossil/test/framework.h>
+
+#include "fossil/tofu/framework.h"
+
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// * Fossil Logic Test Utilities
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// Setup steps for things like test fixtures and
+// mock objects are set here.
+// * * * * * * * * * * * * * * * * * * * * * * * *
+
+FOSSIL_TEST_SUITE(c_cqueue_tofu_fixture);
+
+FOSSIL_SETUP(c_cqueue_tofu_fixture) {
+    // Setup the test fixture
+}
+
+FOSSIL_TEARDOWN(c_cqueue_tofu_fixture) {
+    // Teardown the test fixture
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// * Fossil Logic Test Cases
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// The test cases below are provided as samples, inspired
+// by the Meson build system's approach of using test cases
+// as samples for library usage.
+// * * * * * * * * * * * * * * * * * * * * * * * *
+
+FOSSIL_TEST_CASE(c_test_cqueue_insert) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
+    ASSUME_ITS_TRUE(fossil_cqueue_insert(queue, "42") == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_size(queue) == 1);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_remove) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
+    fossil_cqueue_insert(queue, "42");
+    ASSUME_ITS_TRUE(fossil_cqueue_remove(queue) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_not_empty) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
+    fossil_cqueue_insert(queue, "42");
+    ASSUME_ITS_TRUE(fossil_cqueue_not_empty(queue) == true);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_not_cnullptr) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
+    ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(queue) == true);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_is_empty) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
+    fossil_cqueue_insert(queue, "42");
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == false);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_is_cnullptr) {
+    fossil_cqueue_t* queue = NULL;
+    ASSUME_ITS_TRUE(fossil_cqueue_is_cnullptr(queue) == true);
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// * Fossil Logic Test Pool
+// * * * * * * * * * * * * * * * * * * * * * * * *
+FOSSIL_TEST_GROUP(c_cqueue_tofu_tests) {    
+    // Generic ToFu Fixture
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_insert);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_remove);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_not_empty);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_not_cnullptr);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_is_empty);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_is_cnullptr);
+
+    FOSSIL_TEST_REGISTER(c_cqueue_tofu_fixture);
+} // end of tests

--- a/code/tests/cases/test_cqueue.c
+++ b/code/tests/cases/test_cqueue.c
@@ -40,45 +40,76 @@ FOSSIL_TEARDOWN(c_cqueue_tofu_fixture) {
 // as samples for library usage.
 // * * * * * * * * * * * * * * * * * * * * * * * *
 
+// *****************************************************************************
+// Circular Queue Test Cases
+// *****************************************************************************
+
 FOSSIL_TEST_CASE(c_test_cqueue_insert) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
-    ASSUME_ITS_TRUE(fossil_cqueue_insert(queue, "42") == FOSSIL_TOFU_SUCCESS);
-    ASSUME_ITS_TRUE(fossil_cqueue_size(queue) == 1);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    ASSUME_ITS_TRUE(fossil_cqueue_insert(cqueue, "42") == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_size(cqueue) == 1);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(c_test_cqueue_remove) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
-    fossil_cqueue_insert(queue, "42");
-    ASSUME_ITS_TRUE(fossil_cqueue_remove(queue) == FOSSIL_TOFU_SUCCESS);
-    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, "42");
+    ASSUME_ITS_TRUE(fossil_cqueue_remove(cqueue) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == true);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(c_test_cqueue_not_empty) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
-    fossil_cqueue_insert(queue, "42");
-    ASSUME_ITS_TRUE(fossil_cqueue_not_empty(queue) == true);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, "42");
+    ASSUME_ITS_TRUE(fossil_cqueue_not_empty(cqueue) == true);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(c_test_cqueue_not_cnullptr) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
-    ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(queue) == true);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(cqueue) == true);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(c_test_cqueue_is_empty) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container("i32");
-    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
-    fossil_cqueue_insert(queue, "42");
-    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == false);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == true);
+    fossil_cqueue_insert(cqueue, "42");
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == false);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(c_test_cqueue_is_cnullptr) {
-    fossil_cqueue_t* queue = NULL;
-    ASSUME_ITS_TRUE(fossil_cqueue_is_cnullptr(queue) == true);
+    fossil_cqueue_t* cqueue = NULL;
+    ASSUME_ITS_TRUE(fossil_cqueue_is_cnullptr(cqueue) == true);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_get_front_and_rear) {
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, "1");
+    fossil_cqueue_insert(cqueue, "2");
+    fossil_cqueue_insert(cqueue, "3");
+
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_front(cqueue), "1");
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_rear(cqueue), "3");
+
+    fossil_cqueue_destroy(cqueue);
+}
+
+FOSSIL_TEST_CASE(c_test_cqueue_set_front_and_rear) {
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, "1");
+    fossil_cqueue_insert(cqueue, "2");
+    fossil_cqueue_insert(cqueue, "3");
+
+    fossil_cqueue_set_front(cqueue, "42");
+    fossil_cqueue_set_rear(cqueue, "99");
+
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_front(cqueue), "42");
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_rear(cqueue), "99");
+
+    fossil_cqueue_destroy(cqueue);
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -92,6 +123,8 @@ FOSSIL_TEST_GROUP(c_cqueue_tofu_tests) {
     FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_not_cnullptr);
     FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_is_empty);
     FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_is_cnullptr);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_get_front_and_rear);
+    FOSSIL_TEST_ADD(c_cqueue_tofu_fixture, c_test_cqueue_set_front_and_rear);
 
     FOSSIL_TEST_REGISTER(c_cqueue_tofu_fixture);
 } // end of tests

--- a/code/tests/cases/test_cqueue.cpp
+++ b/code/tests/cases/test_cqueue.cpp
@@ -40,84 +40,130 @@ FOSSIL_TEARDOWN(cpp_cqueue_tofu_fixture) {
 // as samples for library usage.
 // * * * * * * * * * * * * * * * * * * * * * * * *
 
+// *****************************************************************************
+// Circular Queue Test Cases
+// *****************************************************************************
+
 FOSSIL_TEST_CASE(cpp_test_cqueue_insert) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
-    ASSUME_ITS_TRUE(fossil_cqueue_insert(queue, const_cast<char *>("42")) == FOSSIL_TOFU_SUCCESS);
-    ASSUME_ITS_TRUE(fossil_cqueue_size(queue) == 1);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    ASSUME_ITS_TRUE(fossil_cqueue_insert(cqueue, const_cast<char*>("42")) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_size(cqueue) == 1);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_remove) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
-    fossil_cqueue_insert(queue, const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(fossil_cqueue_remove(queue) == FOSSIL_TOFU_SUCCESS);
-    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, const_cast<char*>("42"));
+    ASSUME_ITS_TRUE(fossil_cqueue_remove(cqueue) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == true);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_not_empty) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
-    fossil_cqueue_insert(queue, const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(fossil_cqueue_not_empty(queue) == true);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, const_cast<char*>("42"));
+    ASSUME_ITS_TRUE(fossil_cqueue_not_empty(cqueue) == true);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_not_cnullptr) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
-    ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(queue) == true);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(cqueue) == true);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_is_empty) {
-    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
-    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
-    fossil_cqueue_insert(queue, const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == false);
-    fossil_cqueue_destroy(queue);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == true);
+    fossil_cqueue_insert(cqueue, const_cast<char*>("42"));
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == false);
+    fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_is_cnullptr) {
-    fossil_cqueue_t* queue = nullptr;
-    ASSUME_ITS_TRUE(fossil_cqueue_is_cnullptr(queue) == true);
+    fossil_cqueue_t* cqueue = NULL;
+    ASSUME_ITS_TRUE(fossil_cqueue_is_cnullptr(cqueue) == true);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cqueue_template_insert) {
-    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
-    ASSUME_ITS_TRUE(queue.insert(const_cast<char *>("42")) == FOSSIL_TOFU_SUCCESS);
-    ASSUME_ITS_TRUE(queue.size() == 1);
+FOSSIL_TEST_CASE(cpp_test_cqueue_get_front_and_rear) {
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, const_cast<char*>("1"));
+    fossil_cqueue_insert(cqueue, const_cast<char*>("2"));
+    fossil_cqueue_insert(cqueue, const_cast<char*>("3"));
+
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_front(cqueue), "1");
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_rear(cqueue), "3");
+
+    fossil_cqueue_destroy(cqueue);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cqueue_template_remove) {
-    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
-    queue.insert(const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(queue.remove() == FOSSIL_TOFU_SUCCESS);
-    ASSUME_ITS_TRUE(queue.is_empty() == true);
+FOSSIL_TEST_CASE(cpp_test_cqueue_set_front_and_rear) {
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_insert(cqueue, const_cast<char*>("1"));
+    fossil_cqueue_insert(cqueue, const_cast<char*>("2"));
+    fossil_cqueue_insert(cqueue, const_cast<char*>("3"));
+
+    fossil_cqueue_set_front(cqueue, const_cast<char*>("42"));
+    fossil_cqueue_set_rear(cqueue, const_cast<char*>("99"));
+
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_front(cqueue), "42");
+    ASSUME_ITS_EQUAL_CSTR(fossil_cqueue_get_rear(cqueue), "99");
+
+    fossil_cqueue_destroy(cqueue);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cqueue_template_not_empty) {
-    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
-    queue.insert(const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(queue.not_empty() == true);
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_insert) {
+    fossil::tofu::CQueue cqueue("i32");
+    ASSUME_ITS_TRUE(cqueue.insert(const_cast<char*>("42")) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(cqueue.size() == 1);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cqueue_template_is_empty) {
-    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
-    ASSUME_ITS_TRUE(queue.is_empty() == true);
-    queue.insert(const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(queue.is_empty() == false);
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_remove) {
+    fossil::tofu::CQueue cqueue("i32");
+    cqueue.insert(const_cast<char*>("42"));
+    ASSUME_ITS_TRUE(cqueue.remove() == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(cqueue.is_empty() == true);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cqueue_template_get_front) {
-    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
-    queue.insert(const_cast<char *>("42"));
-    ASSUME_ITS_TRUE(std::string(queue.get_front()) == "42");
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_not_empty) {
+    fossil::tofu::CQueue cqueue("i32");
+    cqueue.insert(const_cast<char*>("42"));
+    ASSUME_ITS_TRUE(cqueue.not_empty() == true);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cqueue_template_get_rear) {
-    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
-    queue.insert(const_cast<char *>("42"));
-    queue.insert(const_cast<char *>("84"));
-    ASSUME_ITS_TRUE(std::string(queue.get_rear()) == "84");
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_not_cnullptr) {
+    fossil::tofu::CQueue cqueue("i32");
+    ASSUME_ITS_TRUE(cqueue.not_cnullptr() == true);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_is_empty) {
+    fossil::tofu::CQueue cqueue("i32");
+    ASSUME_ITS_TRUE(cqueue.is_empty() == true);
+    cqueue.insert(const_cast<char*>("42"));
+    ASSUME_ITS_TRUE(cqueue.is_empty() == false);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_get_front_and_rear) {
+    fossil::tofu::CQueue cqueue("i32");
+    cqueue.insert(const_cast<char*>("1"));
+    cqueue.insert(const_cast<char*>("2"));
+    cqueue.insert(const_cast<char*>("3"));
+
+    ASSUME_ITS_EQUAL_CSTR(cqueue.get_front(), "1");
+    ASSUME_ITS_EQUAL_CSTR(cqueue.get_rear(), "3");
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_class_set_front_and_rear) {
+    fossil::tofu::CQueue cqueue("i32");
+    cqueue.insert(const_cast<char*>("1"));
+    cqueue.insert(const_cast<char*>("2"));
+    cqueue.insert(const_cast<char*>("3"));
+
+    cqueue.set_front(const_cast<char*>("42"));
+    cqueue.set_rear(const_cast<char*>("99"));
+
+    ASSUME_ITS_EQUAL_CSTR(cqueue.get_front(), "42");
+    ASSUME_ITS_EQUAL_CSTR(cqueue.get_rear(), "99");
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -131,13 +177,16 @@ FOSSIL_TEST_GROUP(cpp_cqueue_tofu_tests) {
     FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_not_cnullptr);
     FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_is_empty);
     FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_is_cnullptr);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_get_front_and_rear);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_set_front_and_rear);
 
-    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_insert);
-    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_remove);
-    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_not_empty);
-    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_is_empty);
-    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_get_front);
-    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_get_rear);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_insert);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_remove);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_not_empty);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_not_cnullptr);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_is_empty);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_get_front_and_rear);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_class_set_front_and_rear);
 
     FOSSIL_TEST_REGISTER(cpp_cqueue_tofu_fixture);
 } // end of tests

--- a/code/tests/cases/test_cqueue.cpp
+++ b/code/tests/cases/test_cqueue.cpp
@@ -45,14 +45,14 @@ FOSSIL_TEARDOWN(cpp_cqueue_tofu_fixture) {
 // *****************************************************************************
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_insert) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     ASSUME_ITS_TRUE(fossil_cqueue_insert(cqueue, const_cast<char*>("42")) == FOSSIL_TOFU_SUCCESS);
     ASSUME_ITS_TRUE(fossil_cqueue_size(cqueue) == 1);
     fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_remove) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     fossil_cqueue_insert(cqueue, const_cast<char*>("42"));
     ASSUME_ITS_TRUE(fossil_cqueue_remove(cqueue) == FOSSIL_TOFU_SUCCESS);
     ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == true);
@@ -60,20 +60,20 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_remove) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_not_empty) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     fossil_cqueue_insert(cqueue, const_cast<char*>("42"));
     ASSUME_ITS_TRUE(fossil_cqueue_not_empty(cqueue) == true);
     fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_not_cnullptr) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(cqueue) == true);
     fossil_cqueue_destroy(cqueue);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_is_empty) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == true);
     fossil_cqueue_insert(cqueue, const_cast<char*>("42"));
     ASSUME_ITS_TRUE(fossil_cqueue_is_empty(cqueue) == false);
@@ -86,7 +86,7 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_is_cnullptr) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_get_front_and_rear) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     fossil_cqueue_insert(cqueue, const_cast<char*>("1"));
     fossil_cqueue_insert(cqueue, const_cast<char*>("2"));
     fossil_cqueue_insert(cqueue, const_cast<char*>("3"));
@@ -98,7 +98,7 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_get_front_and_rear) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_set_front_and_rear) {
-    fossil_cqueue_t* cqueue = fossil_cqueue_create_container("i32", 5);
+    fossil_cqueue_t* cqueue = fossil_cqueue_create_container(const_cast<char*>("i32"), 5);
     fossil_cqueue_insert(cqueue, const_cast<char*>("1"));
     fossil_cqueue_insert(cqueue, const_cast<char*>("2"));
     fossil_cqueue_insert(cqueue, const_cast<char*>("3"));
@@ -113,38 +113,38 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_set_front_and_rear) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_insert) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     ASSUME_ITS_TRUE(cqueue.insert(const_cast<char*>("42")) == FOSSIL_TOFU_SUCCESS);
     ASSUME_ITS_TRUE(cqueue.size() == 1);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_remove) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     cqueue.insert(const_cast<char*>("42"));
     ASSUME_ITS_TRUE(cqueue.remove() == FOSSIL_TOFU_SUCCESS);
     ASSUME_ITS_TRUE(cqueue.is_empty() == true);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_not_empty) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     cqueue.insert(const_cast<char*>("42"));
     ASSUME_ITS_TRUE(cqueue.not_empty() == true);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_not_cnullptr) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     ASSUME_ITS_TRUE(cqueue.not_cnullptr() == true);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_is_empty) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     ASSUME_ITS_TRUE(cqueue.is_empty() == true);
     cqueue.insert(const_cast<char*>("42"));
     ASSUME_ITS_TRUE(cqueue.is_empty() == false);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_get_front_and_rear) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     cqueue.insert(const_cast<char*>("1"));
     cqueue.insert(const_cast<char*>("2"));
     cqueue.insert(const_cast<char*>("3"));
@@ -154,7 +154,7 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_class_get_front_and_rear) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_set_front_and_rear) {
-    fossil::tofu::CQueue cqueue("i32");
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
     cqueue.insert(const_cast<char*>("1"));
     cqueue.insert(const_cast<char*>("2"));
     cqueue.insert(const_cast<char*>("3"));

--- a/code/tests/cases/test_cqueue.cpp
+++ b/code/tests/cases/test_cqueue.cpp
@@ -113,38 +113,38 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_set_front_and_rear) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_insert) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     ASSUME_ITS_TRUE(cqueue.insert(const_cast<char*>("42")) == FOSSIL_TOFU_SUCCESS);
     ASSUME_ITS_TRUE(cqueue.size() == 1);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_remove) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     cqueue.insert(const_cast<char*>("42"));
     ASSUME_ITS_TRUE(cqueue.remove() == FOSSIL_TOFU_SUCCESS);
     ASSUME_ITS_TRUE(cqueue.is_empty() == true);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_not_empty) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     cqueue.insert(const_cast<char*>("42"));
     ASSUME_ITS_TRUE(cqueue.not_empty() == true);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_not_cnullptr) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     ASSUME_ITS_TRUE(cqueue.not_cnullptr() == true);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_is_empty) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     ASSUME_ITS_TRUE(cqueue.is_empty() == true);
     cqueue.insert(const_cast<char*>("42"));
     ASSUME_ITS_TRUE(cqueue.is_empty() == false);
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_get_front_and_rear) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     cqueue.insert(const_cast<char*>("1"));
     cqueue.insert(const_cast<char*>("2"));
     cqueue.insert(const_cast<char*>("3"));
@@ -154,7 +154,7 @@ FOSSIL_TEST_CASE(cpp_test_cqueue_class_get_front_and_rear) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_cqueue_class_set_front_and_rear) {
-    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"));
+    fossil::tofu::CQueue cqueue(const_cast<char*>("i32"), 5);
     cqueue.insert(const_cast<char*>("1"));
     cqueue.insert(const_cast<char*>("2"));
     cqueue.insert(const_cast<char*>("3"));

--- a/code/tests/cases/test_cqueue.cpp
+++ b/code/tests/cases/test_cqueue.cpp
@@ -1,0 +1,143 @@
+/*
+ * -----------------------------------------------------------------------------
+ * Project: Fossil Logic
+ *
+ * This file is part of the Fossil Logic project, which aims to develop high-
+ * performance, cross-platform applications and libraries. The code contained
+ * herein is subject to the terms and conditions defined in the project license.
+ *
+ * Author: Michael Gene Brockus (Dreamer)
+ *
+ * Copyright (C) 2024 Fossil Logic. All rights reserved.
+ * -----------------------------------------------------------------------------
+ */
+#include <fossil/test/framework.h>
+
+#include "fossil/tofu/framework.h"
+
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// * Fossil Logic Test Utilities
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// Setup steps for things like test fixtures and
+// mock objects are set here.
+// * * * * * * * * * * * * * * * * * * * * * * * *
+
+FOSSIL_TEST_SUITE(cpp_cqueue_tofu_fixture);
+
+FOSSIL_SETUP(cpp_cqueue_tofu_fixture) {
+    // Setup the test fixture
+}
+
+FOSSIL_TEARDOWN(cpp_cqueue_tofu_fixture) {
+    // Teardown the test fixture
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// * Fossil Logic Test Cases
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// The test cases below are provided as samples, inspired
+// by the Meson build system's approach of using test cases
+// as samples for library usage.
+// * * * * * * * * * * * * * * * * * * * * * * * *
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_insert) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
+    ASSUME_ITS_TRUE(fossil_cqueue_insert(queue, const_cast<char *>("42")) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_size(queue) == 1);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_remove) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
+    fossil_cqueue_insert(queue, const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(fossil_cqueue_remove(queue) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_not_empty) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
+    fossil_cqueue_insert(queue, const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(fossil_cqueue_not_empty(queue) == true);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_not_cnullptr) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
+    ASSUME_ITS_TRUE(fossil_cqueue_not_cnullptr(queue) == true);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_is_empty) {
+    fossil_cqueue_t* queue = fossil_cqueue_create_container(const_cast<char *>("i32"));
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == true);
+    fossil_cqueue_insert(queue, const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(fossil_cqueue_is_empty(queue) == false);
+    fossil_cqueue_destroy(queue);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_is_cnullptr) {
+    fossil_cqueue_t* queue = nullptr;
+    ASSUME_ITS_TRUE(fossil_cqueue_is_cnullptr(queue) == true);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_template_insert) {
+    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
+    ASSUME_ITS_TRUE(queue.insert(const_cast<char *>("42")) == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(queue.size() == 1);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_template_remove) {
+    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
+    queue.insert(const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(queue.remove() == FOSSIL_TOFU_SUCCESS);
+    ASSUME_ITS_TRUE(queue.is_empty() == true);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_template_not_empty) {
+    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
+    queue.insert(const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(queue.not_empty() == true);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_template_is_empty) {
+    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
+    ASSUME_ITS_TRUE(queue.is_empty() == true);
+    queue.insert(const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(queue.is_empty() == false);
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_template_get_front) {
+    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
+    queue.insert(const_cast<char *>("42"));
+    ASSUME_ITS_TRUE(std::string(queue.get_front()) == "42");
+}
+
+FOSSIL_TEST_CASE(cpp_test_cqueue_template_get_rear) {
+    fossil::tofu::CQueue queue(const_cast<char *>("i32"));
+    queue.insert(const_cast<char *>("42"));
+    queue.insert(const_cast<char *>("84"));
+    ASSUME_ITS_TRUE(std::string(queue.get_rear()) == "84");
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * *
+// * Fossil Logic Test Pool
+// * * * * * * * * * * * * * * * * * * * * * * * *
+FOSSIL_TEST_GROUP(cpp_cqueue_tofu_tests) {    
+    // Generic ToFu Fixture
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_insert);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_remove);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_not_empty);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_not_cnullptr);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_is_empty);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_is_cnullptr);
+
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_insert);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_remove);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_not_empty);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_is_empty);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_get_front);
+    FOSSIL_TEST_ADD(cpp_cqueue_tofu_fixture, cpp_test_cqueue_template_get_rear);
+
+    FOSSIL_TEST_REGISTER(cpp_cqueue_tofu_fixture);
+} // end of tests

--- a/code/tests/meson.build
+++ b/code/tests/meson.build
@@ -3,7 +3,7 @@ if get_option('with_test').enabled()
 
     test_c   = ['unit_runner.c']
     test_cases = [
-        'tofu', 'tuple', 'vector', 'stack', 'queue', 'dqueue', 'pqueue', 'flist', 'dlist', 'clist', 'setof', 'mapof'
+        'tofu', 'tuple', 'vector', 'stack', 'queue', 'cqueue', 'dqueue', 'pqueue', 'flist', 'dlist', 'clist', 'setof', 'mapof'
     ]
 
     foreach cases : test_cases


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description

This PR introduces a Circular Queue implementation to the ToFu data structure collection. The Circular Queue provides efficient memory utilization by reusing empty slots, making it ideal for scenarios with fixed-size buffers or streaming data. It supports constant-time enqueue and dequeue operations (`O(1)`) and includes error handling for overflow and underflow conditions. Unit tests have been added to ensure reliability across edge cases. This addition further expands ToFu’s comprehensive suite of data structures for embedded and systems-level applications.

## Testing

Added new test cases

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
